### PR TITLE
Use Bazel-managed interpreter for pip_parse

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-rules_python_version = "0.13.0" 
+rules_python_version = "0.13.0"
 
 http_archive(
     name = "rules_python",
@@ -17,12 +17,14 @@ python_register_toolchains(
 )
 
 load("@python3_8//:defs.bzl", "interpreter")
-
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 pip_parse(
-   name = "py_deps",
-   requirements_lock = "//infra/python:requirements_lock.txt",
+    name = "py_deps",
+    python_interpreter_target = interpreter,
+    requirements_lock = "//infra/python:requirements_lock.txt",
 )
+
 load("@py_deps//:requirements.bzl", "install_deps")
+
 install_deps()

--- a/infra/python/BUILD
+++ b/infra/python/BUILD
@@ -2,6 +2,7 @@ load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
 compile_pip_requirements(
     name = "compile_pip_requirements",
-    requirements_in = "//infra/python:requirements.txt",
-    requirements_txt = "//infra/python:requirements_lock.txt",
+    extra_args = ["--allow-unsafe"],
+    requirements_in = "requirements.txt",
+    requirements_txt = "requirements_lock.txt",
 )

--- a/infra/python/requirements_lock.txt
+++ b/infra/python/requirements_lock.txt
@@ -844,9 +844,8 @@ zipp==3.11.0 \
     --hash=sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766
     # via importlib-metadata
 
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools
-
-# Added manually
-setuptools==65.6.3
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==65.6.3 \
+    --hash=sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54 \
+    --hash=sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75
+    # via tensorboard


### PR DESCRIPTION
Without this, `pip_parse` uses the system-installed `python3`. This breaks if `python3` is something else than the configured Python 3.8.

We also pass `--allow-unsafe` to avoid having to manually mess with `requirements_lock.txt`.